### PR TITLE
Optionally allow keeping original column names in fetch_dataframe method

### DIFF
--- a/redshift_connector/cursor.py
+++ b/redshift_connector/cursor.py
@@ -504,13 +504,18 @@ class Cursor:
             else:
                 raise StopIteration()
 
-    def fetch_dataframe(self: "Cursor", num: typing.Optional[int] = None) -> "pandas.DataFrame":
+    def fetch_dataframe(
+        self: "Cursor",
+        num: typing.Optional[int] = None,
+        lowercase_column_names: bool = True,
+    ) -> "pandas.DataFrame":
         """
         Fetches a user defined number of rows of a query result as a :class:`pandas.DataFrame`.
 
         Parameters
         ----------
         num : Optional[int] The number of rows to retrieve. If unspecified, all rows will be retrieved
+        lowercase_column_names : bool If set to True, column names in returend dataframe will be in lower case. Else, original column names are returned.
 
         Returns
         -------
@@ -519,11 +524,18 @@ class Cursor:
         try:
             import pandas
         except ModuleNotFoundError:
-            raise ModuleNotFoundError(MISSING_MODULE_ERROR_MSG.format(module="pandas"))
+            raise ModuleNotFoundError(MISSING_MODULE_ERROR_MSG.format(module="pandas"))        
+
+        def _handle_name(name: typing.Union[str, bytes]) -> typing.Union[str, bytes]:
+            """Inner helper to optionally handle column name"""
+            output = name
+            if lowercase_column_names:
+                output = name.lower()
+            return output
 
         columns: typing.Optional[typing.List[typing.Union[str, bytes]]] = None
         try:
-            columns = [column[0].lower() for column in self.description]
+            columns = [_handle_name(column[0]) for column in self.description]
         except:
             warn("No row description was found. pandas dataframe will be missing column labels.", stacklevel=2)
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
This PR allows caller of the `Cursor.fetch_dataframe()` method to keep the column names as equal to what specified in the SQL statement the cursor executed.

## Description
<!--- Describe your changes in detail -->
Current implementation is lowercasing the column names before supplying them to the `pd.DataFrame` constructor - hardcoded.
This means that foe the following snippet column names are changed:

```
with redshift_connector.connect(...) as connection:
    with connection.cursor() as cur:
        df = cur.execute('SELECT 1 AS FOO, 2 AS BAR').fetch_dataframe()

assert set(df.columns) == {'FOO', 'BAR'}, "Names are not equal"
```

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include code snippits, details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ x] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- - [ ] I have read the **CONTRIBUTING** document [Currently not accepting contributions]-->
- [ ] Local run of `./build.sh` succeeds
- [ ] Code changes have been run against the repository's pre-commit hooks
- [ ] Commit messages follow [Conventional Commit Specification](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] I have read the **README** document
- [ ] I have added tests to cover my changes
- [ ] I have run all unit tests using `pytest test/unit` and they are passing.
<!-- Please note: Our developers will work with you to ensure your changes pass our internal integration test suite.

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
